### PR TITLE
fix: handle Infinity duration in formatTime

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -572,7 +572,7 @@
   }
 
   function formatTime(seconds) {
-    if (!seconds || isNaN(seconds)) return '0:00';
+    if (!seconds || !isFinite(seconds)) return '0:00';
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- Fixes "Infinity:NaN" display on progress bar when audio stream has infinite duration
- Changed `isNaN(seconds)` to `!isFinite(seconds)` which catches both NaN and Infinity values

## Root Cause
When `audio.duration` is `Infinity` (common with streaming content):
- `isNaN(Infinity)` returns `false`, so the check passed
- `Math.floor(Infinity / 60)` returns `Infinity`
- `Math.floor(Infinity % 60)` returns `NaN`
- Result: "Infinity:NaN" displayed

## Solution
`!isFinite(seconds)` returns `true` for both `NaN` and `Infinity`, properly falling back to "0:00".

## Test plan
- [ ] Verify progress bar shows "0:00" instead of "Infinity:NaN" for streams
- [ ] Verify normal tracks still display correct duration

Fixes: https://github.com/erkantaylan/listen-along/issues/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)