### PR TITLE
feat: display active lobbies on home page

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -217,6 +217,24 @@ app.get('/api/stream', async (req, res) => {
   }
 });
 
+// List all active lobbies (public)
+app.get('/api/lobbies', (req, res) => {
+  const allLobbies = lobby.getAllLobbies();
+
+  const lobbies = allLobbies.map(l => {
+    const queue = getQueue(l.id);
+    return {
+      id: l.id,
+      listeningMode: l.listeningMode,
+      userCount: l.userCount,
+      songCount: queue.getSongs().length,
+      createdAt: l.createdAt
+    };
+  });
+
+  res.json({ lobbies });
+});
+
 // Create a new lobby
 app.post('/api/lobbies', (req, res) => {
   const newLobby = lobby.createLobby(null);

--- a/backend/src/lobby.js
+++ b/backend/src/lobby.js
@@ -301,6 +301,22 @@ function leaveLobbySync(lobbyId, socketId) {
   return user;
 }
 
+function getAllLobbies() {
+  const result = [];
+  for (const [id, lobbyData] of lobbies) {
+    const users = lobbyUsers.get(id);
+    const userCount = users ? users.size : 0;
+    result.push({
+      id,
+      listeningMode: lobbyData.listeningMode || 'synchronized',
+      userCount,
+      createdAt: lobbyData.createdAt,
+      lastActivity: lobbyData.lastActivity
+    });
+  }
+  return result;
+}
+
 function getListeningMode(lobbyId) {
   const lobby = lobbies.get(lobbyId);
   return lobby ? lobby.listeningMode || 'synchronized' : 'synchronized';
@@ -317,6 +333,7 @@ module.exports = {
   joinLobby: joinLobbySync,
   leaveLobby: leaveLobbySync,
   getLobbyUsers,
+  getAllLobbies,
   getListeningMode,
   setUserMode,
   getUserMode,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,14 @@
         <p>Have a link? Just paste it in your browser.</p>
       </div>
 
+      <!-- Active Lobbies Section -->
+      <section id="lobbies-section" class="lobbies-section" hidden>
+        <h2>Active Lobbies</h2>
+        <ul id="lobbies-list" class="lobbies-list">
+          <li class="lobbies-empty">No active lobbies</li>
+        </ul>
+      </section>
+
       <!-- Personal Playlists Section -->
       <section id="playlists-section" class="playlists-section" hidden>
         <div class="playlists-header">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1455,6 +1455,89 @@ html, body {
   color: var(--text-muted);
 }
 
+/* Active Lobbies Section */
+.lobbies-section {
+  width: 100%;
+  max-width: 500px;
+  margin-top: 2rem;
+  text-align: left;
+}
+
+.lobbies-section h2 {
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.lobbies-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.lobbies-empty {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  padding: 1rem;
+  text-align: center;
+}
+
+.lobby-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.lobby-card:hover {
+  background: var(--bg-surface);
+}
+
+.lobby-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.lobby-card-id {
+  font-family: monospace;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.lobby-card-stats {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.lobby-card-stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.lobby-card-stat svg {
+  width: 14px;
+  height: 14px;
+  color: var(--text-muted);
+}
+
+.lobby-card-age {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
 /* Playlists Section */
 .playlists-section {
   width: 100%;


### PR DESCRIPTION
## Summary
- Adds public `GET /api/lobbies` API endpoint returning all active lobbies with type, user count, and song count
- Renders an "Active Lobbies" section on the landing page with clickable cards to join
- Auto-refreshes the lobby list every 10 seconds; section hidden when no lobbies exist

Closes #27

## Test plan
- [ ] Create lobbies of both types (synchronized/independent) and verify they appear on the landing page
- [ ] Verify user count and song count update correctly
- [ ] Click a lobby card and verify it joins the lobby
- [ ] Verify the list auto-refreshes (wait 10s or create a new lobby in another tab)
- [ ] Verify the section is hidden when no active lobbies exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)