### PR TITLE
fix: independent mode no longer removes songs from shared queue (la-48h)

### DIFF
--- a/backend/src/queue.js
+++ b/backend/src/queue.js
@@ -8,6 +8,7 @@ class Queue {
   constructor(lobbyId) {
     this.lobbyId = lobbyId;
     this.songs = [];
+    this.userPositions = new Map(); // userId -> index (for independent mode)
   }
 
   addSong({ url, title, duration, addedBy, thumbnail }) {
@@ -135,6 +136,37 @@ class Queue {
     }
 
     return current;
+  }
+
+  getSongAtIndex(index) {
+    return this.songs[index] || null;
+  }
+
+  getUserPosition(userId) {
+    return this.userPositions.get(userId) || 0;
+  }
+
+  getUserCurrentSong(userId) {
+    const index = this.getUserPosition(userId);
+    return this.songs[index] || null;
+  }
+
+  advanceUserPosition(userId) {
+    const current = this.getUserPosition(userId);
+    const next = current + 1;
+    if (next >= this.songs.length) {
+      return null;
+    }
+    this.userPositions.set(userId, next);
+    return this.songs[next];
+  }
+
+  setUserPosition(userId, index) {
+    this.userPositions.set(userId, index);
+  }
+
+  removeUserPosition(userId) {
+    this.userPositions.delete(userId);
   }
 
   clear() {


### PR DESCRIPTION
## Summary
- In independent mode, `playback:ended` and `playback:next` handlers called `advanceQueue()` which removed songs from the shared queue, breaking other users' playback
- Added per-user position tracking in Queue class (`userPositions` Map) so each user advances their own index through the queue without modifying it
- Server-side handlers now check for independent mode and use per-user position tracking instead of queue mutation
- User position is cleaned up on disconnect

## Test plan
- [x] All 132 existing + new tests pass
- [ ] Verify independent mode: two users in same lobby, track end for one user does not remove songs for the other
- [ ] Verify repeat-all in independent mode wraps around to queue start
- [ ] Verify synchronized mode behavior is unchanged

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)