### PR TITLE
feat: rename lobbies and validate unique names

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -49,6 +49,7 @@ async function createTables() {
     CREATE TABLE IF NOT EXISTS lobbies (
       id VARCHAR(8) PRIMARY KEY,
       host_id VARCHAR(255),
+      name VARCHAR(50),
       listening_mode VARCHAR(20) DEFAULT 'synchronized',
       created_at BIGINT NOT NULL,
       last_activity BIGINT NOT NULL
@@ -136,6 +137,14 @@ async function createTables() {
   await pool.query(createPlaylistsTable);
   await pool.query(createPlaylistSongsTable);
   await pool.query(createIndexes);
+
+  // Migration: add name column to existing lobbies table
+  await pool.query(`
+    DO $$ BEGIN
+      ALTER TABLE lobbies ADD COLUMN name VARCHAR(50);
+    EXCEPTION WHEN duplicate_column THEN NULL;
+    END $$
+  `);
 
   console.log('Database tables initialized');
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -225,6 +225,7 @@ app.get('/api/lobbies', (req, res) => {
     const queue = getQueue(l.id);
     return {
       id: l.id,
+      name: l.name || null,
       listeningMode: l.listeningMode,
       userCount: l.userCount,
       songCount: queue.getSongs().length,
@@ -252,6 +253,7 @@ app.get('/api/lobbies/:id', (req, res) => {
   }
   res.json({
     id: lobbyData.id,
+    name: lobbyData.name || null,
     userCount: lobbyData.users.size,
     users: lobby.getLobbyUsers(req.params.id)
   });
@@ -615,8 +617,15 @@ io.on('connection', (socket) => {
   let currentLobby = null;
 
   // Create a new lobby
-  socket.on('lobby:create', ({ username, listeningMode }) => {
-    const newLobby = lobby.createLobby(null, null, listeningMode);
+  socket.on('lobby:create', ({ username, listeningMode, name }) => {
+    // Validate unique name if provided
+    const lobbyName = name ? name.trim().substring(0, 50) : null;
+    if (lobbyName && lobby.isNameTaken(lobbyName)) {
+      socket.emit('lobby:error', { message: 'A lobby with that name already exists' });
+      return;
+    }
+
+    const newLobby = lobby.createLobby(null, null, listeningMode, lobbyName);
     const result = lobby.joinLobby(newLobby.id, socket.id, username || 'Anonymous');
 
     currentLobby = newLobby.id;
@@ -624,12 +633,13 @@ io.on('connection', (socket) => {
 
     socket.emit('lobby:created', {
       lobbyId: newLobby.id,
+      name: newLobby.name,
       listeningMode: newLobby.listeningMode,
       user: result.user,
       users: lobby.getLobbyUsers(newLobby.id)
     });
 
-    console.log(`Lobby ${newLobby.id} created by ${username} (${newLobby.listeningMode})`);
+    console.log(`Lobby ${newLobby.id} created by ${username} (${newLobby.listeningMode})${newLobby.name ? ` name="${newLobby.name}"` : ''}`);
   });
 
   socket.on('join-lobby', ({ lobbyId, username }) => {
@@ -643,8 +653,10 @@ io.on('connection', (socket) => {
     socket.join(lobbyId);
 
     // Notify the joining user
+    const joinedLobbyData = lobby.getLobby(lobbyId);
     socket.emit('joined-lobby', {
       lobbyId,
+      name: joinedLobbyData ? joinedLobbyData.name : null,
       listeningMode: lobby.getListeningMode(lobbyId),
       user: result.user,
       users: lobby.getLobbyUsers(lobbyId)
@@ -704,6 +716,7 @@ io.on('connection', (socket) => {
     const listeningMode = lobby.getListeningMode(lobbyId);
     socket.emit('lobby:joined', {
       lobbyId,
+      name: lobbyData.name || null,
       listeningMode,
       user: result.user,
       users: lobby.getLobbyUsers(lobbyId)
@@ -733,6 +746,31 @@ io.on('connection', (socket) => {
     socket.leave(lobbyId);
     console.log(`Client ${socket.id} left lobby ${lobbyId}`);
     currentLobby = null;
+  });
+
+  // Rename a lobby
+  socket.on('lobby:rename', ({ lobbyId, name }) => {
+    if (!lobbyId) lobbyId = currentLobby;
+    if (!lobbyId) return;
+
+    if (!name || !name.trim()) {
+      socket.emit('lobby:error', { message: 'Lobby name cannot be empty' });
+      return;
+    }
+
+    const result = lobby.renameLobby(lobbyId, name);
+    if (!result) {
+      socket.emit('lobby:error', { message: 'Lobby not found' });
+      return;
+    }
+    if (result.error) {
+      socket.emit('lobby:error', { message: result.error });
+      return;
+    }
+
+    // Broadcast rename to all users in the lobby
+    io.to(lobbyId).emit('lobby:renamed', { lobbyId, name: result.name });
+    console.log(`Lobby ${lobbyId} renamed to "${result.name}"`);
   });
 
   // Set user mode (listening or lobby)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,6 +39,9 @@
           <span class="lobby-type-desc">Shared queue, own playback</span>
         </label>
       </div>
+      <div class="lobby-name-input">
+        <input type="text" id="lobby-name-input" placeholder="Lobby name (optional)" maxlength="50" autocomplete="off">
+      </div>
       <button id="create-lobby-btn" class="btn btn-primary btn-large">
         Create Lobby
       </button>
@@ -80,7 +83,12 @@
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>
       </button>
       <div class="lobby-info">
-        <h2 id="lobby-name">Lobby</h2>
+        <div class="lobby-name-wrapper">
+          <h2 id="lobby-name">Lobby</h2>
+          <button id="rename-lobby-btn" class="btn-icon btn-icon-small" aria-label="Rename lobby" title="Rename lobby">
+            <svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16"><path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34c-.39-.39-1.02-.39-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"/></svg>
+          </button>
+        </div>
         <span id="listening-mode-badge" class="listening-mode-badge" hidden></span>
         <span id="user-count" class="user-count">0 listeners</span>
       </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -191,6 +191,58 @@ html, body {
   color: #ffa500;
 }
 
+.lobby-name-input {
+  width: 100%;
+  max-width: 280px;
+  margin-bottom: 1rem;
+}
+
+.lobby-name-input input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--bg-surface);
+  border: 1px solid transparent;
+  border-radius: var(--border-radius);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.lobby-name-input input:focus {
+  border-color: var(--primary);
+}
+
+.lobby-name-input input::placeholder {
+  color: var(--text-muted);
+}
+
+.lobby-name-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.lobby-name-wrapper h2 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lobby-name-wrapper .btn-icon {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  min-width: 28px;
+  padding: 0;
+}
+
+.lobby-name-wrapper .btn-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
 .join-section {
   margin-top: 2rem;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Add optional lobby name field on create (text input on landing page)
- Add rename UI in lobby header (edit button next to lobby name)
- Validate lobby names are unique (case-insensitive) on both create and rename
- Names are trimmed and capped at 50 characters
- Active lobbies list shows custom names when set

Closes #30

## Changes
- **backend/src/lobby.js**: Added `name` field to lobby model, `renameLobby()` and `isNameTaken()` functions
- **backend/src/db.js**: Added `name` column to lobbies table with migration for existing DBs
- **backend/src/index.js**: Added `lobby:rename` socket event, name validation on create, name in API responses
- **frontend/app.js**: Lobby name input on create, rename via prompt, `lobby:renamed` event handling
- **frontend/index.html**: Name input field, edit button in lobby header
- **frontend/style.css**: Styling for name input and rename button
- **backend/src/lobby.test.js**: 18 new tests for naming, renaming, and uniqueness validation

## Test plan
- [x] All 10 lobby test suites pass (32 existing + 18 new tests)
- [ ] Create lobby without name - defaults to "Lobby {id}"
- [ ] Create lobby with name - shows custom name
- [ ] Create lobby with duplicate name - shows error
- [ ] Rename lobby - updates for all users in lobby
- [ ] Rename to taken name - shows error
- [ ] Active lobbies list shows custom names

🤖 Generated with [Claude Code](https://claude.com/claude-code)