### PR TITLE
Fix duplicate join notification shown to both users

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1337,6 +1337,8 @@
       state.listeners.push(data.user);
     }
     updateListeners();
+    // Don't show join notification to the user who just joined
+    if (data.user.socketId === socket.id) return;
     const joinDisplay = data.user.emoji ? `${data.user.emoji} ${data.user.username}` : data.user.username;
     showToast(`${joinDisplay} joined`, 'success');
   }


### PR DESCRIPTION
Skip showing the 'joined' toast notification when the joining user's socketId matches the current socket, so only existing lobby members see the join notification.

Fixes GH#55