### PR TITLE
Remove dead code and consolidate duplicate lobby join handlers

### DIFF
--- a/backend/src/downloader.js
+++ b/backend/src/downloader.js
@@ -329,48 +329,6 @@ async function downloadSong(songId, url, lobbyId = null) {
 }
 
 /**
- * Get download status for a URL
- * @param {string} url - YouTube URL
- * @returns {Promise<Object|null>} Status info or null
- */
-async function getDownloadStatus(url) {
-  // Check active downloads first for real-time progress
-  const active = activeDownloads.get(url);
-  if (active) {
-    return {
-      id: active.songId,
-      status: active.status,
-      percent: active.percent,
-      ready: active.status === 'ready'
-    };
-  }
-
-  const song = await getCachedSong(url);
-  if (!song) return null;
-
-  return {
-    id: song.id,
-    status: song.status,
-    percent: song.status === 'ready' ? 100 : 0,
-    ready: song.status === 'ready' && isCachedFileValid(song.file_path),
-    error: song.error_message
-  };
-}
-
-/**
- * Get download status for multiple URLs
- * @param {string[]} urls - Array of YouTube URLs
- * @returns {Promise<Object>} Map of url -> status
- */
-async function getDownloadStatuses(urls) {
-  const statuses = {};
-  for (const url of urls) {
-    statuses[url] = await getDownloadStatus(url);
-  }
-  return statuses;
-}
-
-/**
  * Get all cached songs
  * @returns {Promise<Array>} Array of song records
  */
@@ -496,8 +454,6 @@ module.exports = {
   isCachedFileValid,
   createCachedStream,
   startDownload,
-  getDownloadStatus,
-  getDownloadStatuses,
   getAllSongs,
   deleteSong,
   deleteAllSongs,

--- a/backend/src/downloader.test.js
+++ b/backend/src/downloader.test.js
@@ -57,11 +57,4 @@ describe('downloader', () => {
     });
   });
 
-  describe('getDownloadStatus', () => {
-    it('returns null when database is unavailable', async () => {
-      const downloader = require('./downloader');
-      const result = await downloader.getDownloadStatus('https://youtube.com/watch?v=test');
-      assert.strictEqual(result, null);
-    });
-  });
 });

--- a/backend/src/ytdlp.js
+++ b/backend/src/ytdlp.js
@@ -57,33 +57,6 @@ function getMetadata(query) {
 }
 
 /**
- * Create an audio stream for a YouTube video
- * @param {string} query - YouTube URL or search term
- * @returns {Object} { stream, proc } - Audio stream and process handle
- */
-function createAudioStream(query) {
-  const isUrl = query.startsWith('http://') || query.startsWith('https://');
-  const target = isUrl ? query : `ytsearch:${query}`;
-
-  const args = [
-    '-f', 'bestaudio',
-    '-o', '-',                 // Output to stdout
-    '--no-playlist',
-    target
-  ];
-
-  const proc = spawn('yt-dlp', args, {
-    stdio: ['ignore', 'pipe', 'pipe']
-  });
-
-  return {
-    stream: proc.stdout,
-    proc,
-    kill: () => proc.kill('SIGTERM')
-  };
-}
-
-/**
  * Create a transcoded audio stream (converts to mp3 via ffmpeg)
  * @param {string} query - YouTube URL or search term
  * @returns {Object} { stream, kill } - Audio stream and cleanup function
@@ -288,7 +261,6 @@ function getPlaylistItems(url, limit = 50) {
 
 module.exports = {
   getMetadata,
-  createAudioStream,
   createTranscodedStream,
   parseError,
   checkAvailable,


### PR DESCRIPTION
- Remove createAudioStream from ytdlp.js (unused, only createTranscodedStream is used)
- Remove getDownloadStatus and getDownloadStatuses from downloader.js (exported but never called)
- Remove duplicate join-lobby handler from index.js (lobby:join handles the same thing with better error handling)
- Remove dead leave-lobby handler (frontend uses lobby:leave)
- Remove test for deleted getDownloadStatus function