### PR TITLE
feat: add Spotify track and playlist link support (li-g0q)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -15,6 +15,7 @@ const downloader = require('./downloader');
 const covers = require('./covers');
 const playlist = require('./playlist');
 const chat = require('./chat');
+const spotify = require('./spotify');
 const pkg = require('../package.json');
 
 const PORT = process.env.PORT || 3000;
@@ -999,8 +1000,79 @@ io.on('connection', (socket) => {
     const queue = await getQueueAsync(lobbyId);
     const inputUrl = url || query;
 
+    // Check if this is a Spotify URL
+    const spotifyParsed = inputUrl ? spotify.parseSpotifyUrl(inputUrl) : null;
+    if (spotifyParsed) {
+      if (!spotify.isEnabled()) {
+        socket.emit('queue:error', { message: 'Spotify links are not supported on this server — try pasting a YouTube link instead' });
+        return;
+      }
+
+      try {
+        if (spotifyParsed.type === 'playlist') {
+          // Spotify playlist: fetch tracks, present confirmation dialog
+          socket.emit('queue:adding', { status: 'Loading Spotify playlist...' });
+          const playlist = await spotify.getPlaylistTracks(spotifyParsed.id);
+
+          if (playlist.items.length === 0) {
+            socket.emit('queue:error', { message: 'Spotify playlist is empty' });
+            return;
+          }
+
+          // Cache playlist items for confirmation
+          cachePlaylist(inputUrl, {
+            title: playlist.title,
+            items: playlist.items.map(item => ({
+              title: item.title,
+              duration: item.duration,
+              thumbnail: item.thumbnail,
+              // Store searchQuery so we can find on YouTube later
+              url: `ytsearch:${item.searchQuery}`,
+              uploader: item.artist
+            })),
+            total: playlist.total,
+            limited: playlist.limited
+          });
+
+          socket.emit('queue:playlist-confirm', {
+            lobbyId,
+            url: inputUrl,
+            playlistTitle: playlist.title,
+            songCount: playlist.items.length,
+            totalCount: playlist.total,
+            limited: playlist.limited,
+            firstSong: playlist.items[0] ? { title: playlist.items[0].title, duration: playlist.items[0].duration } : null,
+            songMeta: null,
+            addedBy
+          });
+          return;
+        }
+
+        // Spotify track: fetch metadata and search YouTube
+        socket.emit('queue:adding', { status: 'Looking up Spotify track...' });
+        const trackInfo = await spotify.getTrack(spotifyParsed.id);
+
+        socket.emit('queue:adding', { status: 'Finding on YouTube...' });
+        const metadata = await ytdlp.getMetadata(`ytsearch:${trackInfo.searchQuery}`);
+
+        if (!metadata) {
+          socket.emit('queue:error', { message: `Could not find "${trackInfo.title}" on YouTube` });
+          return;
+        }
+
+        url = metadata.url;
+        title = trackInfo.title;
+        duration = metadata.duration;
+        thumbnail = trackInfo.thumbnail || metadata.thumbnail;
+      } catch (err) {
+        console.error('Spotify processing error:', err);
+        socket.emit('queue:error', { message: `Failed to process Spotify link: ${err.message}` });
+        return;
+      }
+    }
+
     // Check if this is a playlist URL
-    if (inputUrl && ytdlp.isPlaylistUrl(inputUrl)) {
+    if (!spotifyParsed && inputUrl && ytdlp.isPlaylistUrl(inputUrl)) {
       try {
         // Check if URL also contains a specific video (watch?v=xxx&list=yyy)
         let videoId = null;
@@ -1541,6 +1613,9 @@ async function start() {
   } else {
     console.log('Running in memory-only mode');
   }
+
+  // Initialize Spotify integration (logs status, no-op if creds missing)
+  spotify.init();
 
   server.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);

--- a/backend/src/spotify.js
+++ b/backend/src/spotify.js
@@ -1,0 +1,215 @@
+const https = require('https');
+
+let accessToken = null;
+let tokenExpiry = 0;
+let enabled = false;
+
+const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID;
+const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET;
+
+/**
+ * Initialize Spotify integration.
+ * Logs status and returns whether Spotify is enabled.
+ */
+function init() {
+  if (!SPOTIFY_CLIENT_ID || !SPOTIFY_CLIENT_SECRET) {
+    console.log('Spotify integration disabled: missing SPOTIFY_CLIENT_ID/SPOTIFY_CLIENT_SECRET');
+    enabled = false;
+    return false;
+  }
+  enabled = true;
+  console.log('Spotify integration enabled');
+  return true;
+}
+
+/**
+ * Check if Spotify integration is enabled
+ */
+function isEnabled() {
+  return enabled;
+}
+
+/**
+ * Check if a URL is a Spotify track or playlist URL
+ * @param {string} url
+ * @returns {{ type: 'track'|'playlist', id: string } | null}
+ */
+function parseSpotifyUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'open.spotify.com') return null;
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    const type = parts[0];
+    const id = parts[1];
+    if (type === 'track' && id) return { type: 'track', id };
+    if (type === 'playlist' && id) return { type: 'playlist', id };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get an access token using Client Credentials flow
+ */
+function getAccessToken() {
+  return new Promise((resolve, reject) => {
+    if (accessToken && Date.now() < tokenExpiry) {
+      return resolve(accessToken);
+    }
+
+    const credentials = Buffer.from(`${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`).toString('base64');
+    const body = 'grant_type=client_credentials';
+
+    const options = {
+      hostname: 'accounts.spotify.com',
+      path: '/api/token',
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Content-Length': Buffer.byteLength(body)
+      }
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          return reject(new Error(`Spotify auth failed (${res.statusCode}): ${data}`));
+        }
+        try {
+          const json = JSON.parse(data);
+          accessToken = json.access_token;
+          // Expire 60 seconds early to avoid edge cases
+          tokenExpiry = Date.now() + (json.expires_in - 60) * 1000;
+          resolve(accessToken);
+        } catch (e) {
+          reject(new Error('Failed to parse Spotify auth response'));
+        }
+      });
+    });
+
+    req.on('error', (err) => {
+      reject(new Error(`Spotify auth request failed: ${err.message}`));
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+/**
+ * Make a request to the Spotify API
+ * @param {string} path - API path (e.g., /v1/tracks/xxx)
+ * @returns {Promise<Object>}
+ */
+async function spotifyApi(path) {
+  const token = await getAccessToken();
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'api.spotify.com',
+      path,
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`
+      }
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode !== 200) {
+          return reject(new Error(`Spotify API error (${res.statusCode}): ${data.slice(0, 200)}`));
+        }
+        try {
+          resolve(JSON.parse(data));
+        } catch (e) {
+          reject(new Error('Failed to parse Spotify API response'));
+        }
+      });
+    });
+
+    req.on('error', (err) => {
+      reject(new Error(`Spotify API request failed: ${err.message}`));
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * Get track metadata from Spotify
+ * @param {string} trackId - Spotify track ID
+ * @returns {Promise<{ title: string, artist: string, thumbnail: string, duration: number, searchQuery: string }>}
+ */
+async function getTrack(trackId) {
+  const data = await spotifyApi(`/v1/tracks/${encodeURIComponent(trackId)}`);
+  const artists = data.artists.map(a => a.name).join(', ');
+  const title = data.name;
+  const thumbnail = data.album && data.album.images && data.album.images.length > 0
+    ? data.album.images[0].url
+    : null;
+  const duration = data.duration_ms ? data.duration_ms / 1000 : 0;
+
+  return {
+    title: `${title} - ${artists}`,
+    artist: artists,
+    thumbnail,
+    duration,
+    searchQuery: `${title} ${artists}`
+  };
+}
+
+/**
+ * Get all tracks from a Spotify playlist
+ * @param {string} playlistId - Spotify playlist ID
+ * @param {number} limit - Maximum number of tracks (default 50)
+ * @returns {Promise<{ title: string, items: Array<{ title: string, artist: string, thumbnail: string, duration: number, searchQuery: string }> }>}
+ */
+async function getPlaylistTracks(playlistId, limit = 50) {
+  const data = await spotifyApi(`/v1/playlists/${encodeURIComponent(playlistId)}?fields=name,tracks.items(track(name,artists(name),album(images),duration_ms)),tracks.total`);
+  const playlistTitle = data.name || 'Spotify Playlist';
+  const trackItems = data.tracks && data.tracks.items ? data.tracks.items : [];
+  const total = data.tracks && data.tracks.total ? data.tracks.total : trackItems.length;
+
+  const items = trackItems
+    .slice(0, limit)
+    .filter(item => item.track)
+    .map(item => {
+      const track = item.track;
+      const artists = track.artists.map(a => a.name).join(', ');
+      const title = track.name;
+      const thumbnail = track.album && track.album.images && track.album.images.length > 0
+        ? track.album.images[0].url
+        : null;
+      const duration = track.duration_ms ? track.duration_ms / 1000 : 0;
+
+      return {
+        title: `${title} - ${artists}`,
+        artist: artists,
+        thumbnail,
+        duration,
+        searchQuery: `${title} ${artists}`
+      };
+    });
+
+  return {
+    title: playlistTitle,
+    items,
+    total,
+    limited: total > limit
+  };
+}
+
+module.exports = {
+  init,
+  isEnabled,
+  parseSpotifyUrl,
+  getTrack,
+  getPlaylistTracks
+};

--- a/backend/src/spotify.test.js
+++ b/backend/src/spotify.test.js
@@ -1,0 +1,54 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { parseSpotifyUrl } = require('./spotify');
+
+describe('spotify', () => {
+  describe('parseSpotifyUrl', () => {
+    it('parses a track URL', () => {
+      const result = parseSpotifyUrl('https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT');
+      assert.deepStrictEqual(result, { type: 'track', id: '4cOdK2wGLETKBW3PvgPWqT' });
+    });
+
+    it('parses a playlist URL', () => {
+      const result = parseSpotifyUrl('https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M');
+      assert.deepStrictEqual(result, { type: 'playlist', id: '37i9dQZF1DXcBWIGoYBM5M' });
+    });
+
+    it('parses a track URL with query parameters', () => {
+      const result = parseSpotifyUrl('https://open.spotify.com/track/4cOdK2wGLETKBW3PvgPWqT?si=abcdef123456');
+      assert.deepStrictEqual(result, { type: 'track', id: '4cOdK2wGLETKBW3PvgPWqT' });
+    });
+
+    it('returns null for YouTube URLs', () => {
+      assert.strictEqual(parseSpotifyUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ'), null);
+    });
+
+    it('returns null for non-Spotify URLs', () => {
+      assert.strictEqual(parseSpotifyUrl('https://example.com/track/abc'), null);
+    });
+
+    it('returns null for Spotify URLs without type', () => {
+      assert.strictEqual(parseSpotifyUrl('https://open.spotify.com/'), null);
+    });
+
+    it('returns null for unsupported Spotify types', () => {
+      assert.strictEqual(parseSpotifyUrl('https://open.spotify.com/album/abc123'), null);
+    });
+
+    it('returns null for null input', () => {
+      assert.strictEqual(parseSpotifyUrl(null), null);
+    });
+
+    it('returns null for undefined input', () => {
+      assert.strictEqual(parseSpotifyUrl(undefined), null);
+    });
+
+    it('returns null for empty string', () => {
+      assert.strictEqual(parseSpotifyUrl(''), null);
+    });
+
+    it('returns null for non-URL string', () => {
+      assert.strictEqual(parseSpotifyUrl('not a url'), null);
+    });
+  });
+});


### PR DESCRIPTION
Parse open.spotify.com/track/ and /playlist/ URLs, fetch metadata via Spotify API (Client Credentials flow), then search YouTube for audio. Gracefully degrades when SPOTIFY_CLIENT_ID/SECRET are not configured.