### PR TITLE
Add play button to playlist items

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2709,6 +2709,9 @@
           </div>
         </div>
         <div class="queue-item-actions">
+          <button class="btn-icon queue-item-play" aria-label="Play" onclick="window.app.soloPlayTrack(${index})">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+          </button>
           <button class="btn-icon queue-item-remove" aria-label="Remove from playlist" onclick="window.app.soloRemoveSong(${index})">
             <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
           </button>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -832,6 +832,15 @@ html, body {
   height: 18px;
 }
 
+.queue-item-play {
+  padding: 0.5rem;
+  color: var(--text-muted);
+}
+
+.queue-item-play:hover {
+  color: var(--primary);
+}
+
 .queue-item-remove {
   padding: 0.5rem;
   color: var(--text-muted);


### PR DESCRIPTION
Adds a visible play button (triangle icon) to each song in the solo playlist view, allowing users to jump directly to any song. The button uses the existing soloPlayTrack function and is styled consistently with the existing remove button.

Closes #53