### PR TITLE
feat: add play button to each song in lobby queue

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1901,6 +1901,32 @@
     });
   }
 
+  function playSongAt(index) {
+    const song = state.queue[index];
+    if (!song) return;
+
+    if (state.listeningMode === 'independent') {
+      playLocalTrack(song);
+      return;
+    }
+
+    // Synchronized mode
+    if (index === 0) {
+      // Already playing - restart from beginning
+      socket.emit('playback:seek', { lobbyId: state.lobbyId, position: 0 });
+      return;
+    }
+    // Move song to next-up position then skip to it
+    if (index !== 1) {
+      socket.emit('queue:reorder', {
+        lobbyId: state.lobbyId,
+        songId: song.id,
+        newIndex: 1
+      });
+    }
+    socket.emit('playback:next', { lobbyId: state.lobbyId });
+  }
+
   // UI Updates
   function updateNowPlaying(track) {
     elements.trackTitle.textContent = track.title || 'Unknown Track';
@@ -2041,6 +2067,9 @@
               </button>
             </div>
           ` : ''}
+          <button class="btn-icon queue-item-play" aria-label="Play" onclick="window.app.playSongAt(${index})">
+            <svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+          </button>
           <button class="btn-icon queue-item-remove" aria-label="Remove from queue" onclick="window.app.removeSong(${index})">
             <svg viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
           </button>
@@ -2891,6 +2920,7 @@
     removeSong,
     moveSongUp,
     moveSongDown,
+    playSongAt,
     openPlaylist,
     deletePlaylist: deletePlaylistAction,
     soloPlayTrack: soloPlayTrack,

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -865,6 +865,10 @@ html, body {
   color: var(--primary);
 }
 
+.queue-item-play:active {
+  transform: scale(0.9);
+}
+
 .queue-item-remove {
   padding: 0.5rem;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- Add a play button on each song in the queue list
- In independent mode, plays the track locally
- In synchronized mode, reorders queue and skips to play the selected song
- Includes press animation on the play button

Closes #71

## Bead
li-595

## Convoy
hq-cv-qtlli

🤖 Generated with [Claude Code](https://claude.com/claude-code)