### PR TITLE
fix: sanitize path traversal and open redirect vulnerabilities

### DIFF
--- a/backend/src/covers.js
+++ b/backend/src/covers.js
@@ -66,6 +66,10 @@ function getExtension(url, contentType) {
 async function cacheCover(songId, thumbnailUrl) {
   if (!thumbnailUrl) return null;
 
+  // Sanitize songId to prevent path traversal
+  songId = path.basename(songId);
+  if (!songId) return null;
+
   try {
     ensureCoversDir();
 
@@ -125,6 +129,10 @@ async function cacheCover(songId, thumbnailUrl) {
  * @returns {{ path: string, contentType: string } | null}
  */
 function getCachedCover(songId) {
+  // Sanitize songId to prevent path traversal
+  songId = path.basename(songId);
+  if (!songId) return null;
+
   // Check memory cache first
   if (coverCache.has(songId)) {
     const cached = coverCache.get(songId);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -354,13 +354,27 @@ app.get('/api/covers/:id', (req, res) => {
 
   const cached = covers.getCachedCover(songId);
   if (cached) {
+    // Validate cached path is within COVERS_DIR to prevent path traversal
+    const resolvedPath = path.resolve(cached.path);
+    const coversBase = path.resolve(covers.COVERS_DIR);
+    if (!resolvedPath.startsWith(coversBase + path.sep) && resolvedPath !== coversBase) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
     res.setHeader('Content-Type', cached.contentType);
     res.setHeader('Cache-Control', 'public, max-age=86400'); // Cache for 1 day
-    return res.sendFile(cached.path);
+    return res.sendFile(resolvedPath);
   }
 
-  // Not cached - redirect to fallback URL if provided
+  // Not cached - redirect to fallback URL if provided (validate to prevent open redirect)
   if (fallbackUrl) {
+    try {
+      const parsed = new URL(fallbackUrl);
+      if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return res.status(400).json({ error: 'Invalid fallback URL' });
+      }
+    } catch {
+      return res.status(400).json({ error: 'Invalid fallback URL' });
+    }
     return res.redirect(fallbackUrl);
   }
 


### PR DESCRIPTION
## Summary
- **covers.js**: Sanitize `songId` with `path.basename()` in `cacheCover()` and `getCachedCover()` to prevent path traversal (CodeQL alerts #12, #13, #14)
- **index.js**: Validate `cached.path` resolves within `COVERS_DIR` before `res.sendFile()` (defense in depth)
- **index.js**: Validate `fallbackUrl` has `http:`/`https:` protocol before `res.redirect()` to prevent open redirects (CodeQL alert #1)

## Test plan
- [x] All 196 existing backend tests pass
- [ ] Verify `/api/covers/../../../etc/passwd` returns 404 (songId sanitized)
- [ ] Verify `/api/covers/test?fallback=javascript:alert(1)` returns 400
- [ ] Verify `/api/covers/test?fallback=https://example.com/img.jpg` still redirects

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)