### PR TITLE
fix: track shuffle history for correct previous song navigation (#86)

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -173,6 +173,10 @@ async function createTables() {
     ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS song_mention TEXT
   `).catch(() => {}); // Ignore if column already exists
 
+  await pool.query(`
+    ALTER TABLE playback_state ADD COLUMN IF NOT EXISTS shuffle_history JSONB DEFAULT '[]'
+  `).catch(() => {}); // Ignore if column already exists
+
   console.log('Database tables initialized');
 }
 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1501,7 +1501,9 @@ io.on('connection', (socket) => {
 
     if (shuffleState.shuffleEnabled && songs.length > 1) {
       // Shuffle mode: get next index from shuffle order
-      const nextIndex = playback.getNextShuffleIndex(lobbyId, songs.length);
+      const currentState = playback.getState(lobbyId);
+      const currentTrackId = currentState && currentState.currentTrack ? currentState.currentTrack.id : null;
+      const nextIndex = playback.getNextShuffleIndex(lobbyId, songs.length, currentTrackId);
       if (nextIndex !== null && songs[nextIndex]) {
         const nextSong = songs[nextIndex];
         console.log(`Shuffle: playing song at index ${nextIndex} in lobby ${lobbyId}: ${nextSong.title}`);
@@ -1568,6 +1570,21 @@ io.on('connection', (socket) => {
       return;
     }
 
+    const shuffleState = playback.getShuffleState(lobbyId);
+    const songs = queue.getSongs();
+
+    if (shuffleState.shuffleEnabled && songs.length > 1) {
+      // Shuffle mode: pick next from shuffle order, record history
+      const currentState = playback.getState(lobbyId);
+      const currentTrackId = currentState && currentState.currentTrack ? currentState.currentTrack.id : null;
+      const nextIndex = playback.getNextShuffleIndex(lobbyId, songs.length, currentTrackId);
+      if (nextIndex !== null && songs[nextIndex]) {
+        playback.setTrack(lobbyId, songs[nextIndex], true, io);
+      }
+      io.to(lobbyId).emit('queue:update', { lobbyId, songs });
+      return;
+    }
+
     if (repeatMode === 'all') {
       // Move current song to end of queue (circular)
       queue.moveCurrentToEnd();
@@ -1610,6 +1627,27 @@ io.on('connection', (socket) => {
     const queue = await getQueueAsync(lobbyId);
     const songs = queue.getSongs();
     if (songs.length === 0) return;
+
+    const shuffleState = playback.getShuffleState(lobbyId);
+
+    // In shuffle mode, use history to go back to the actual previous song
+    if (shuffleState.shuffleEnabled) {
+      const prevTrackId = playback.getPreviousShuffleTrackId(lobbyId);
+      if (prevTrackId) {
+        const prevSong = songs.find(s => s.id === prevTrackId);
+        if (prevSong) {
+          playback.setTrack(lobbyId, prevSong, true, io);
+          io.to(lobbyId).emit('queue:update', { lobbyId, songs: queue.getSongs() });
+          return;
+        }
+      }
+      // No history or song not found — restart current track
+      playback.seek(lobbyId, 0, io);
+      if (!state.isPlaying) {
+        playback.resume(lobbyId, io);
+      }
+      return;
+    }
 
     const currentIndex = state.currentTrack
       ? songs.findIndex(s => s.id === state.currentTrack.id)
@@ -1668,6 +1706,24 @@ io.on('connection', (socket) => {
     const currentSong = queue.getCurrentSong();
     if (!currentSong) {
       playback.trackEnded(lobbyId, io);
+      return;
+    }
+
+    const shuffleState = playback.getShuffleState(lobbyId);
+    const songs = queue.getSongs();
+
+    if (shuffleState.shuffleEnabled && songs.length > 1) {
+      // Shuffle mode: pick next from shuffle order, record history
+      const currentState = playback.getState(lobbyId);
+      const currentTrackId = currentState && currentState.currentTrack ? currentState.currentTrack.id : null;
+      const nextIndex = playback.getNextShuffleIndex(lobbyId, songs.length, currentTrackId);
+      if (nextIndex !== null && songs[nextIndex]) {
+        playback.setTrack(lobbyId, songs[nextIndex], true, io);
+        console.log(`Shuffle: playing song at index ${nextIndex} in lobby ${lobbyId}: ${songs[nextIndex].title}`);
+      } else {
+        playback.trackEnded(lobbyId, io);
+      }
+      io.to(lobbyId).emit('queue:update', { lobbyId, songs });
       return;
     }
 

--- a/backend/src/playback.js
+++ b/backend/src/playback.js
@@ -35,6 +35,7 @@ function initLobby(lobbyId) {
     shuffleEnabled: false,   // Shuffle mode toggle
     shuffledIndices: [],     // Shuffled playback order (indices into queue)
     shuffleIndex: 0,         // Current position in shuffled order
+    shuffleHistory: [],      // Stack of previously-played track IDs for back navigation
     repeatMode: 'off',       // 'off', 'all', 'one'
   };
 
@@ -55,7 +56,7 @@ async function initLobbyFromDB(lobbyId) {
   if (db.isAvailable()) {
     try {
       const result = await db.query(
-        'SELECT current_track, position, is_playing, shuffle_enabled, shuffled_indices, shuffle_index, repeat_mode FROM playback_state WHERE lobby_id = $1',
+        'SELECT current_track, position, is_playing, shuffle_enabled, shuffled_indices, shuffle_index, shuffle_history, repeat_mode FROM playback_state WHERE lobby_id = $1',
         [lobbyId]
       );
 
@@ -69,6 +70,7 @@ async function initLobbyFromDB(lobbyId) {
         state.shuffleEnabled = row.shuffle_enabled || false;
         state.shuffledIndices = row.shuffled_indices || [];
         state.shuffleIndex = row.shuffle_index || 0;
+        state.shuffleHistory = row.shuffle_history || [];
         state.repeatMode = row.repeat_mode || 'off';
       }
     } catch (err) {
@@ -90,8 +92,8 @@ async function persistState(lobbyId) {
 
   try {
     await db.query(
-      `INSERT INTO playback_state (lobby_id, current_track, position, is_playing, shuffle_enabled, shuffled_indices, shuffle_index, repeat_mode)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      `INSERT INTO playback_state (lobby_id, current_track, position, is_playing, shuffle_enabled, shuffled_indices, shuffle_index, shuffle_history, repeat_mode)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
        ON CONFLICT (lobby_id) DO UPDATE SET
          current_track = $2,
          position = $3,
@@ -99,7 +101,8 @@ async function persistState(lobbyId) {
          shuffle_enabled = $5,
          shuffled_indices = $6,
          shuffle_index = $7,
-         repeat_mode = $8`,
+         shuffle_history = $8,
+         repeat_mode = $9`,
       [
         lobbyId,
         state.currentTrack ? JSON.stringify(state.currentTrack) : null,
@@ -108,6 +111,7 @@ async function persistState(lobbyId) {
         state.shuffleEnabled,
         JSON.stringify(state.shuffledIndices),
         state.shuffleIndex,
+        JSON.stringify(state.shuffleHistory),
         state.repeatMode
       ]
     );
@@ -440,6 +444,7 @@ function toggleShuffle(lobbyId, enabled, queueLength, io) {
   if (!state) return null;
 
   state.shuffleEnabled = enabled;
+  state.shuffleHistory = [];
 
   if (enabled && queueLength > 0) {
     // Generate shuffled indices (0 to queueLength-1)
@@ -474,12 +479,18 @@ function getShuffleState(lobbyId) {
 
 /**
  * Get next song index when shuffle is enabled
- * Returns the queue index of the next song to play
+ * Returns the queue index of the next song to play.
+ * Pushes the current track onto shuffle history for back-navigation.
  */
-function getNextShuffleIndex(lobbyId, queueLength) {
+function getNextShuffleIndex(lobbyId, queueLength, currentTrackId) {
   const state = getState(lobbyId);
   if (!state || !state.shuffleEnabled || queueLength === 0) {
     return null;
+  }
+
+  // Record current track in history so "previous" can return to it
+  if (currentTrackId) {
+    state.shuffleHistory.push(currentTrackId);
   }
 
   // Move to next position in shuffle order
@@ -495,6 +506,25 @@ function getNextShuffleIndex(lobbyId, queueLength) {
   persistState(lobbyId);
 
   return state.shuffledIndices[state.shuffleIndex];
+}
+
+/**
+ * Get previous song ID from shuffle history.
+ * Pops from the history stack so repeated back-presses walk further back.
+ * Returns the track ID of the previously-played song, or null if no history.
+ */
+function getPreviousShuffleTrackId(lobbyId) {
+  const state = getState(lobbyId);
+  if (!state || !state.shuffleEnabled || state.shuffleHistory.length === 0) {
+    return null;
+  }
+
+  const previousTrackId = state.shuffleHistory.pop();
+
+  // Persist state
+  persistState(lobbyId);
+
+  return previousTrackId;
 }
 
 /**
@@ -606,6 +636,7 @@ module.exports = {
   toggleShuffle,
   getShuffleState,
   getNextShuffleIndex,
+  getPreviousShuffleTrackId,
   updateShuffleForQueueChange,
   stopSyncTimer,
   // Exported for testing

--- a/backend/src/playback.test.js
+++ b/backend/src/playback.test.js
@@ -363,6 +363,70 @@ describe('Playback Module', () => {
       const stateAfter = playback.getState('test-lobby');
       assert.equal(stateAfter.shuffledIndices.length, 5);
     });
+
+    test('getNextShuffleIndex records current track in history', () => {
+      const io = createMockIo();
+      playback.initLobby('test-lobby');
+      playback.toggleShuffle('test-lobby', true, 5, io);
+
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-A');
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-B');
+
+      const state = playback.getState('test-lobby');
+      assert.deepStrictEqual(state.shuffleHistory, ['track-A', 'track-B']);
+    });
+
+    test('getNextShuffleIndex does not record null track', () => {
+      const io = createMockIo();
+      playback.initLobby('test-lobby');
+      playback.toggleShuffle('test-lobby', true, 5, io);
+
+      playback.getNextShuffleIndex('test-lobby', 5, null);
+
+      const state = playback.getState('test-lobby');
+      assert.deepStrictEqual(state.shuffleHistory, []);
+    });
+
+    test('getPreviousShuffleTrackId pops from history', () => {
+      const io = createMockIo();
+      playback.initLobby('test-lobby');
+      playback.toggleShuffle('test-lobby', true, 5, io);
+
+      // Build up history
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-A');
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-B');
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-C');
+
+      // Go back
+      assert.equal(playback.getPreviousShuffleTrackId('test-lobby'), 'track-C');
+      assert.equal(playback.getPreviousShuffleTrackId('test-lobby'), 'track-B');
+      assert.equal(playback.getPreviousShuffleTrackId('test-lobby'), 'track-A');
+      assert.equal(playback.getPreviousShuffleTrackId('test-lobby'), null);
+    });
+
+    test('toggleShuffle clears history', () => {
+      const io = createMockIo();
+      playback.initLobby('test-lobby');
+      playback.toggleShuffle('test-lobby', true, 5, io);
+
+      playback.getNextShuffleIndex('test-lobby', 5, 'track-A');
+      assert.equal(playback.getState('test-lobby').shuffleHistory.length, 1);
+
+      // Toggling off should clear history
+      playback.toggleShuffle('test-lobby', false, 5, io);
+      assert.deepStrictEqual(playback.getState('test-lobby').shuffleHistory, []);
+
+      // Toggling back on should also have empty history
+      playback.toggleShuffle('test-lobby', true, 5, io);
+      assert.deepStrictEqual(playback.getState('test-lobby').shuffleHistory, []);
+    });
+
+    test('getPreviousShuffleTrackId returns null when shuffle disabled', () => {
+      const io = createMockIo();
+      playback.initLobby('test-lobby');
+
+      assert.equal(playback.getPreviousShuffleTrackId('test-lobby'), null);
+    });
   });
 
   describe('setRepeatMode', () => {


### PR DESCRIPTION
## Summary
- Track shuffle playback history as a stack
- Previous button now returns to the actual last-played song instead of picking a new random one
- Adds shuffle history to playback state in DB

Closes #86