### PR TITLE
feat: add Google and GitHub OAuth login (#69)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,9 +8,14 @@
       "name": "listen-along-backend",
       "version": "2.23.0",
       "dependencies": {
+        "connect-pg-simple": "^10.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
+        "express-session": "^1.19.0",
+        "passport": "^0.7.0",
+        "passport-github2": "^0.1.12",
+        "passport-google-oauth20": "^2.0.0",
         "pg": "^8.11.3",
         "qrcode": "^1.5.4",
         "socket.io": "^4.8.1",
@@ -559,6 +564,15 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -891,6 +905,18 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/connect-pg-simple": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
+      "integrity": "sha512-pBGVazlqiMrackzCr0eKhn4LO5trJXsOX0nQoey9wCOayh80MYtThCbq8eoLsjpiWgiok/h+1/uti9/2/Una8A==",
+      "license": "MIT",
+      "dependencies": {
+        "pg": "^8.12.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
       }
     },
     "node_modules/content-disposition": {
@@ -1442,6 +1468,29 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-session": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
+      "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "~0.7.2",
+        "cookie-signature": "~1.0.7",
+        "debug": "~2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.1.0",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "~5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2015,6 +2064,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2044,6 +2099,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2110,6 +2174,75 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2151,6 +2284,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/pg": {
       "version": "8.18.0",
@@ -2543,6 +2681,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/range-parser": {
@@ -3250,6 +3397,24 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.21.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,9 +9,14 @@
     "test": "NODE_ENV=test node --test"
   },
   "dependencies": {
+    "connect-pg-simple": "^10.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
+    "express-session": "^1.19.0",
+    "passport": "^0.7.0",
+    "passport-github2": "^0.1.12",
+    "passport-google-oauth20": "^2.0.0",
     "pg": "^8.11.3",
     "qrcode": "^1.5.4",
     "socket.io": "^4.8.1",

--- a/backend/src/auth.js
+++ b/backend/src/auth.js
@@ -1,0 +1,208 @@
+/**
+ * OAuth authentication module using Passport.js
+ * Supports Google OAuth 2.0 and GitHub OAuth
+ */
+
+const passport = require('passport');
+const GoogleStrategy = require('passport-google-oauth20').Strategy;
+const GitHubStrategy = require('passport-github2').Strategy;
+const db = require('./db');
+
+/**
+ * Find or create a user from OAuth profile data
+ */
+async function findOrCreateUser(provider, profile) {
+  const providerId = profile.id;
+  const email = profile.emails && profile.emails[0] ? profile.emails[0].value : null;
+  const name = profile.displayName || (profile.username ? profile.username : 'User');
+  const avatar = profile.photos && profile.photos[0] ? profile.photos[0].value : null;
+
+  if (!db.isAvailable()) {
+    // Return a transient user object if DB is unavailable
+    return { id: `${provider}_${providerId}`, provider, provider_id: providerId, email, name, avatar_url: avatar };
+  }
+
+  // Try to find existing user
+  const existing = await db.query(
+    'SELECT * FROM users WHERE provider = $1 AND provider_id = $2',
+    [provider, providerId]
+  );
+
+  if (existing.rows.length > 0) {
+    // Update last_login and refresh profile data
+    await db.query(
+      `UPDATE users SET name = $1, email = $2, avatar_url = $3, last_login = $4 WHERE id = $5`,
+      [name, email, avatar, Date.now(), existing.rows[0].id]
+    );
+    return { ...existing.rows[0], name, email, avatar_url: avatar };
+  }
+
+  // Create new user
+  const result = await db.query(
+    `INSERT INTO users (provider, provider_id, email, name, avatar_url, created_at, last_login)
+     VALUES ($1, $2, $3, $4, $5, $6, $6) RETURNING *`,
+    [provider, providerId, email, name, avatar, Date.now()]
+  );
+
+  return result.rows[0];
+}
+
+/**
+ * Initialize Passport strategies and serialization
+ */
+function init() {
+  // Serialize user to session (store only ID)
+  passport.serializeUser((user, done) => {
+    done(null, user.id);
+  });
+
+  // Deserialize user from session
+  passport.deserializeUser(async (id, done) => {
+    try {
+      if (!db.isAvailable()) {
+        return done(null, { id });
+      }
+      const result = await db.query('SELECT * FROM users WHERE id = $1', [id]);
+      if (result.rows.length === 0) {
+        return done(null, false);
+      }
+      done(null, result.rows[0]);
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  // Google OAuth Strategy
+  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+    passport.use(new GoogleStrategy({
+      clientID: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      callbackURL: '/auth/google/callback'
+    }, async (accessToken, refreshToken, profile, done) => {
+      try {
+        const user = await findOrCreateUser('google', profile);
+        done(null, user);
+      } catch (err) {
+        done(err);
+      }
+    }));
+    console.log('Google OAuth strategy configured');
+  } else {
+    console.log('Google OAuth not configured (set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET)');
+  }
+
+  // GitHub OAuth Strategy
+  if (process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET) {
+    passport.use(new GitHubStrategy({
+      clientID: process.env.GITHUB_CLIENT_ID,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET,
+      callbackURL: '/auth/github/callback',
+      scope: ['user:email']
+    }, async (accessToken, refreshToken, profile, done) => {
+      try {
+        const user = await findOrCreateUser('github', profile);
+        done(null, user);
+      } catch (err) {
+        done(err);
+      }
+    }));
+    console.log('GitHub OAuth strategy configured');
+  } else {
+    console.log('GitHub OAuth not configured (set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET)');
+  }
+}
+
+/**
+ * Set up auth routes on the Express app
+ */
+function setupRoutes(app) {
+  // Google OAuth
+  app.get('/auth/google', passport.authenticate('google', {
+    scope: ['profile', 'email']
+  }));
+
+  app.get('/auth/google/callback',
+    passport.authenticate('google', { failureRedirect: '/login' }),
+    (req, res) => {
+      res.redirect('/');
+    }
+  );
+
+  // GitHub OAuth
+  app.get('/auth/github', passport.authenticate('github', {
+    scope: ['user:email']
+  }));
+
+  app.get('/auth/github/callback',
+    passport.authenticate('github', { failureRedirect: '/login' }),
+    (req, res) => {
+      res.redirect('/');
+    }
+  );
+
+  // Logout
+  app.post('/auth/logout', (req, res) => {
+    req.logout((err) => {
+      if (err) {
+        return res.status(500).json({ error: 'Logout failed' });
+      }
+      req.session.destroy(() => {
+        res.clearCookie('connect.sid');
+        res.json({ success: true });
+      });
+    });
+  });
+
+  // Get current user
+  app.get('/api/auth/user', (req, res) => {
+    if (req.isAuthenticated()) {
+      const user = req.user;
+      res.json({
+        authenticated: true,
+        user: {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          avatar: user.avatar_url,
+          provider: user.provider
+        }
+      });
+    } else {
+      res.json({ authenticated: false });
+    }
+  });
+
+  // Login page route
+  app.get('/login', (req, res) => {
+    if (req.isAuthenticated()) {
+      return res.redirect('/');
+    }
+    const path = require('path');
+    const frontendPath = process.env.FRONTEND_PATH || path.join(__dirname, '../frontend');
+    res.sendFile(path.join(frontendPath, 'login.html'));
+  });
+}
+
+/**
+ * Auth guard middleware - redirects unauthenticated requests to login
+ */
+function requireAuth(req, res, next) {
+  if (req.isAuthenticated()) {
+    return next();
+  }
+
+  // API requests get 401
+  if (req.path.startsWith('/api/')) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  // Page requests redirect to login
+  res.redirect('/login');
+}
+
+module.exports = {
+  init,
+  setupRoutes,
+  requireAuth,
+  passport
+};

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -133,6 +133,29 @@ async function createTables() {
     )
   `;
 
+  const createUsersTable = `
+    CREATE TABLE IF NOT EXISTS users (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      provider VARCHAR(20) NOT NULL,
+      provider_id VARCHAR(255) NOT NULL,
+      email VARCHAR(255),
+      name VARCHAR(255),
+      avatar_url TEXT,
+      created_at BIGINT NOT NULL,
+      last_login BIGINT NOT NULL,
+      UNIQUE(provider, provider_id)
+    )
+  `;
+
+  const createSessionTable = `
+    CREATE TABLE IF NOT EXISTS "session" (
+      "sid" VARCHAR NOT NULL COLLATE "default",
+      "sess" JSON NOT NULL,
+      "expire" TIMESTAMP(6) NOT NULL,
+      CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
+    )
+  `;
+
   const createIndexes = `
     CREATE INDEX IF NOT EXISTS idx_queue_songs_lobby ON queue_songs(lobby_id, sort_order);
     CREATE INDEX IF NOT EXISTS idx_lobbies_last_activity ON lobbies(last_activity);
@@ -141,6 +164,8 @@ async function createTables() {
     CREATE INDEX IF NOT EXISTS idx_playlists_user ON playlists(user_id);
     CREATE INDEX IF NOT EXISTS idx_playlist_songs_playlist ON playlist_songs(playlist_id, sort_order);
     CREATE INDEX IF NOT EXISTS idx_chat_messages_lobby ON chat_messages(lobby_id, created_at);
+    CREATE INDEX IF NOT EXISTS idx_users_provider ON users(provider, provider_id);
+    CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");
   `;
 
   await pool.query(createLobbiesTable);
@@ -150,6 +175,8 @@ async function createTables() {
   await pool.query(createPlaylistsTable);
   await pool.query(createPlaylistSongsTable);
   await pool.query(createChatMessagesTable);
+  await pool.query(createUsersTable);
+  await pool.query(createSessionTable);
   await pool.query(createIndexes);
 
   // Migrations for existing databases
@@ -229,11 +256,19 @@ async function close() {
   }
 }
 
+/**
+ * Get the connection pool (for session store, etc.)
+ */
+function getPool() {
+  return pool;
+}
+
 module.exports = {
   init,
   isAvailable,
   query,
   getClient,
+  getPool,
   cleanupExpiredLobbies,
   close
 };

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,8 @@ const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const session = require('express-session');
+const PgSession = require('connect-pg-simple')(session);
 const ytdlp = require('./ytdlp');
 const playback = require('./playback');
 const lobby = require('./lobby');
@@ -17,6 +19,7 @@ const covers = require('./covers');
 const playlist = require('./playlist');
 const chat = require('./chat');
 const spotify = require('./spotify');
+const auth = require('./auth');
 const QRCode = require('qrcode');
 const pkg = require('../package.json');
 
@@ -100,15 +103,81 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(express.json());
 
+// Session configuration
+const SESSION_SECRET = process.env.SESSION_SECRET || crypto.randomBytes(32).toString('hex');
+if (!process.env.SESSION_SECRET) {
+  console.log('Warning: SESSION_SECRET not set, using random secret (sessions will not persist across restarts)');
+}
+
+const sessionConfig = {
+  secret: SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    secure: process.env.NODE_ENV === 'production',
+    httpOnly: true,
+    maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+    sameSite: 'lax'
+  }
+};
+
+// Use PostgreSQL session store if database is available (configured in start())
+let sessionMiddleware;
+function initSession(pgPool) {
+  if (pgPool) {
+    sessionConfig.store = new PgSession({
+      pool: pgPool,
+      tableName: 'session',
+      createTableIfMissing: true
+    });
+  }
+  sessionMiddleware = session(sessionConfig);
+  app.use(sessionMiddleware);
+
+  // Initialize Passport
+  auth.init();
+  app.use(auth.passport.initialize());
+  app.use(auth.passport.session());
+
+  // Auth routes (public)
+  auth.setupRoutes(app);
+}
+
 // Serve static frontend files
 // In Docker: /app/src/index.js -> /app/frontend (../frontend)
 // Local dev: backend/src/index.js -> frontend (../../frontend)
 const frontendPath = process.env.FRONTEND_PATH || path.join(__dirname, '../frontend');
+
+// Serve login page static assets without auth
+app.get('/login', (req, res) => {
+  if (req.isAuthenticated && req.isAuthenticated()) {
+    return res.redirect('/');
+  }
+  res.sendFile(path.join(frontendPath, 'login.html'));
+});
 app.use(express.static(frontendPath));
 
 // Socket.IO setup with CORS
 const io = new Server(server, {
   cors: corsOptions
+});
+
+// Auth guard - protect all routes except public ones
+app.use((req, res, next) => {
+  // Public paths that don't require authentication
+  const publicPaths = ['/health', '/auth/', '/login', '/api/auth/user', '/api/version'];
+  const isPublic = publicPaths.some(p => req.path === p || req.path.startsWith(p));
+  if (isPublic) return next();
+
+  // Static assets are already served above by express.static
+  // If we get here with a non-API path and it wasn't caught by static, apply auth
+  if (req.isAuthenticated && !req.isAuthenticated()) {
+    if (req.path.startsWith('/api/')) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+    return res.redirect('/login');
+  }
+  next();
 });
 
 // Health check endpoint
@@ -725,7 +794,7 @@ app.delete('/api/dashboard/lobbies/:id', dashboardAuth, (req, res) => {
   res.json({ success: true });
 });
 
-// Serve lobby page
+// Serve lobby page (auth guard applied above)
 app.get('/lobby/:id', (req, res) => {
   res.sendFile(path.join(frontendPath, 'index.html'));
 });
@@ -735,7 +804,7 @@ app.get('/dashboard', dashboardAuth, (req, res) => {
   res.sendFile(path.join(frontendPath, 'index.html'));
 });
 
-// Serve index for root
+// Serve index for root (auth guard applied above)
 app.get('/', (req, res) => {
   res.sendFile(path.join(frontendPath, 'index.html'));
 });
@@ -1772,6 +1841,11 @@ async function handleLeave(socket, lobbyId) {
 async function start() {
   // Initialize database if DATABASE_URL is set
   const dbAvailable = await db.init();
+
+  // Initialize session middleware (with or without DB store)
+  const pgPool = dbAvailable ? db.getPool() : null;
+  initSession(pgPool);
+
   if (dbAvailable) {
     console.log('Database persistence enabled');
 
@@ -1795,6 +1869,11 @@ async function start() {
 
   // Initialize Spotify integration (logs status, no-op if creds missing)
   spotify.init();
+
+  // Share session with Socket.IO for authenticated socket connections
+  if (sessionMiddleware) {
+    io.engine.use(sessionMiddleware);
+  }
 
   server.listen(PORT, () => {
     console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- Google OAuth 2.0 and GitHub OAuth login via passport.js
- Session-based auth with express-session
- All routes behind authentication guard — login page is the only public route
- User info (name, email, avatar, provider) stored in SQLite users table
- New `backend/src/auth.js` module for auth configuration

### Environment variables needed
- `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
- `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
- `SESSION_SECRET`

Closes #69