### PR TITLE
feat: add user management and manual approval on dashboard (#97)

### DIFF
--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -141,18 +141,10 @@ async function createTables() {
       email VARCHAR(255),
       name VARCHAR(255),
       avatar_url TEXT,
+      status VARCHAR(20) DEFAULT 'pending',
       created_at BIGINT NOT NULL,
       last_login BIGINT NOT NULL,
       UNIQUE(provider, provider_id)
-    )
-  `;
-
-  const createSessionTable = `
-    CREATE TABLE IF NOT EXISTS "session" (
-      "sid" VARCHAR NOT NULL COLLATE "default",
-      "sess" JSON NOT NULL,
-      "expire" TIMESTAMP(6) NOT NULL,
-      CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
     )
   `;
 
@@ -165,7 +157,7 @@ async function createTables() {
     CREATE INDEX IF NOT EXISTS idx_playlist_songs_playlist ON playlist_songs(playlist_id, sort_order);
     CREATE INDEX IF NOT EXISTS idx_chat_messages_lobby ON chat_messages(lobby_id, created_at);
     CREATE INDEX IF NOT EXISTS idx_users_provider ON users(provider, provider_id);
-    CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");
+    CREATE INDEX IF NOT EXISTS idx_users_status ON users(status);
   `;
 
   await pool.query(createLobbiesTable);
@@ -176,7 +168,6 @@ async function createTables() {
   await pool.query(createPlaylistSongsTable);
   await pool.query(createChatMessagesTable);
   await pool.query(createUsersTable);
-  await pool.query(createSessionTable);
   await pool.query(createIndexes);
 
   // Migrations for existing databases

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -96,7 +96,7 @@ const server = http.createServer(app);
 // CORS configuration
 const corsOptions = {
   origin: FRONTEND_URL,
-  methods: ['GET', 'POST'],
+  methods: ['GET', 'POST', 'PUT', 'DELETE'],
   credentials: true
 };
 
@@ -199,6 +199,82 @@ app.get('/api/version', (req, res) => {
     version: process.env.VERSION || pkg.version,
     name: pkg.name
   });
+});
+
+// User registration / status check
+app.post('/api/auth/register', async (req, res) => {
+  if (!db.isAvailable()) {
+    // No database — skip approval, everyone is approved
+    return res.json({ status: 'approved' });
+  }
+
+  const { userId, username, emoji } = req.body;
+  if (!userId || !username) {
+    return res.status(400).json({ error: 'userId and username are required' });
+  }
+
+  try {
+    // Check if user already exists
+    const existing = await db.query(
+      'SELECT id, user_id, username, emoji, status, created_at FROM users WHERE user_id = $1',
+      [userId]
+    );
+
+    if (existing.rows.length > 0) {
+      const user = existing.rows[0];
+      // Update username/emoji if changed
+      if (user.username !== username || user.emoji !== (emoji || null)) {
+        await db.query(
+          'UPDATE users SET username = $1, emoji = $2, updated_at = $3 WHERE user_id = $4',
+          [username, emoji || null, Date.now(), userId]
+        );
+      }
+      return res.json({ status: user.status, userId: user.user_id });
+    }
+
+    // New user — check if this is the first user (auto-approve)
+    const countResult = await db.query('SELECT COUNT(*) as count FROM users');
+    const isFirst = parseInt(countResult.rows[0].count) === 0;
+    const status = isFirst ? 'approved' : 'pending';
+
+    const now = Date.now();
+    await db.query(
+      `INSERT INTO users (user_id, username, emoji, provider, status, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+      [userId, username, emoji || null, 'local', status, now, now]
+    );
+
+    return res.json({ status, userId });
+  } catch (err) {
+    console.error('User registration error:', err.message);
+    res.status(500).json({ error: 'Registration failed' });
+  }
+});
+
+// Check user approval status
+app.get('/api/auth/status', async (req, res) => {
+  if (!db.isAvailable()) {
+    return res.json({ status: 'approved' });
+  }
+
+  const userId = req.query.userId;
+  if (!userId) {
+    return res.status(400).json({ error: 'userId is required' });
+  }
+
+  try {
+    const result = await db.query(
+      'SELECT status FROM users WHERE user_id = $1',
+      [userId]
+    );
+    if (result.rows.length === 0) {
+      return res.json({ status: 'unregistered' });
+    }
+    res.json({ status: result.rows[0].status });
+  } catch (err) {
+    console.error('Auth status error:', err.message);
+    res.status(500).json({ error: 'Failed to check status' });
+  }
 });
 
 // Generate QR code for a lobby invite link
@@ -767,6 +843,57 @@ app.delete('/api/dashboard/cache/orphaned', dashboardAuth, async (req, res) => {
   }
 });
 
+// List all registered users (dashboard only)
+app.get('/api/dashboard/users', dashboardAuth, async (req, res) => {
+  if (!db.isAvailable()) {
+    return res.json({ users: [] });
+  }
+
+  try {
+    const result = await db.query(
+      'SELECT id, user_id, username, emoji, email, avatar_url, provider, status, created_at, updated_at FROM users ORDER BY created_at DESC'
+    );
+    res.json({ users: result.rows });
+  } catch (err) {
+    console.error('List users error:', err.message);
+    res.status(500).json({ error: 'Failed to fetch users' });
+  }
+});
+
+// Approve a user (dashboard only)
+app.put('/api/dashboard/users/:id/approve', dashboardAuth, async (req, res) => {
+  try {
+    const result = await db.query(
+      'UPDATE users SET status = $1, updated_at = $2 WHERE id = $3 RETURNING user_id, username, status',
+      ['approved', Date.now(), req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.json({ success: true, user: result.rows[0] });
+  } catch (err) {
+    console.error('Approve user error:', err.message);
+    res.status(500).json({ error: 'Failed to approve user' });
+  }
+});
+
+// Reject a user (dashboard only)
+app.put('/api/dashboard/users/:id/reject', dashboardAuth, async (req, res) => {
+  try {
+    const result = await db.query(
+      'UPDATE users SET status = $1, updated_at = $2 WHERE id = $3 RETURNING user_id, username, status',
+      ['rejected', Date.now(), req.params.id]
+    );
+    if (result.rows.length === 0) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    res.json({ success: true, user: result.rows[0] });
+  } catch (err) {
+    console.error('Reject user error:', err.message);
+    res.status(500).json({ error: 'Failed to reject user' });
+  }
+});
+
 // Delete a lobby (dashboard only)
 app.delete('/api/dashboard/lobbies/:id', dashboardAuth, (req, res) => {
   const lobbyId = req.params.id;
@@ -861,8 +988,26 @@ io.on('connection', (socket) => {
     return socket.rooms.has(lobbyId);
   };
 
+  // Check user approval status (returns true if approved or DB unavailable)
+  const checkUserApproved = async (userId) => {
+    if (!db.isAvailable() || !userId) return true;
+    try {
+      const result = await db.query('SELECT status FROM users WHERE user_id = $1', [userId]);
+      if (result.rows.length === 0) return true; // Unregistered users pass through (frontend handles registration)
+      return result.rows[0].status === 'approved';
+    } catch {
+      return true; // On DB error, allow access
+    }
+  };
+
   // Create a new lobby
-  socket.on('lobby:create', async ({ username, emoji, listeningMode, name, lobbyId: requestedId }) => {
+  socket.on('lobby:create', async ({ username, emoji, listeningMode, name, lobbyId: requestedId, userId }) => {
+    // Check user approval
+    if (!(await checkUserApproved(userId))) {
+      socket.emit('lobby:error', { message: 'Your account is pending approval' });
+      return;
+    }
+
     // Validate name uniqueness if provided
     if (name && name.trim()) {
       const trimmedName = name.trim();
@@ -906,7 +1051,13 @@ io.on('connection', (socket) => {
   });
 
   // Handle joining a lobby room (integrates with lobby system)
-  socket.on('lobby:join', async ({ lobbyId, username, emoji }) => {
+  socket.on('lobby:join', async ({ lobbyId, username, emoji, userId }) => {
+    // Check user approval
+    if (!(await checkUserApproved(userId))) {
+      socket.emit('lobby:error', { message: 'Your account is pending approval' });
+      return;
+    }
+
     // Check if lobby exists; if not, ask user to select room type
     let lobbyData = await lobby.getLobbyAsync(lobbyId);
     if (!lobbyData) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -145,6 +145,13 @@
     landingView: document.getElementById('landing-view'),
     lobbyView: document.getElementById('lobby-view'),
     dashboardView: document.getElementById('dashboard-view'),
+    pendingView: document.getElementById('pending-view'),
+
+    // Pending Approval
+    pendingIcon: document.getElementById('pending-icon'),
+    pendingTitle: document.getElementById('pending-title'),
+    pendingMessage: document.getElementById('pending-message'),
+    pendingRetryBtn: document.getElementById('pending-retry-btn'),
 
     // Landing
     createLobbyBtn: document.getElementById('create-lobby-btn'),
@@ -276,6 +283,14 @@
     clearErrorsBtn: document.getElementById('clear-errors-btn'),
     cleanOrphansBtn: document.getElementById('clean-orphans-btn'),
 
+    // Dashboard User Management
+    dashboardUserList: document.getElementById('dashboard-user-list'),
+    usersApproved: document.getElementById('users-approved'),
+    usersPending: document.getElementById('users-pending'),
+    usersRejected: document.getElementById('users-rejected'),
+    usersSearch: document.getElementById('users-search'),
+    usersFilter: document.getElementById('users-filter'),
+
     // Room Type Modal
     roomTypeModal: document.getElementById('room-type-modal'),
     roomTypeLobbyName: document.getElementById('room-type-lobby-name'),
@@ -295,6 +310,54 @@
   // Lobbies auto-refresh state
   let lobbiesInterval = null;
 
+  // User registration and approval
+  async function registerUser() {
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: state.userId,
+          username: state.username,
+          emoji: state.emoji
+        })
+      });
+      if (!res.ok) return 'approved'; // On error, allow access
+      const data = await res.json();
+      return data.status || 'approved';
+    } catch {
+      return 'approved'; // On network error, allow access
+    }
+  }
+
+  function setupPendingRetry() {
+    if (elements.pendingRetryBtn) {
+      elements.pendingRetryBtn.addEventListener('click', async () => {
+        elements.pendingRetryBtn.disabled = true;
+        elements.pendingRetryBtn.textContent = 'Checking...';
+        const status = await registerUser();
+        if (status === 'approved') {
+          // Reload to get full app
+          window.location.reload();
+        } else if (status === 'rejected') {
+          showRejectedView();
+        } else {
+          showToast('Still waiting for approval', 'info');
+          elements.pendingRetryBtn.disabled = false;
+          elements.pendingRetryBtn.textContent = 'Check Status';
+        }
+      });
+    }
+  }
+
+  function showRejectedView() {
+    showView('pending');
+    if (elements.pendingIcon) elements.pendingIcon.textContent = '\u274C';
+    if (elements.pendingTitle) elements.pendingTitle.textContent = 'Access Denied';
+    if (elements.pendingMessage) elements.pendingMessage.textContent = 'Your account has been rejected by the admin. Contact the administrator for more information.';
+    if (elements.pendingRetryBtn) elements.pendingRetryBtn.style.display = 'none';
+  }
+
   // Initialize Application
   async function init() {
     // Initialize i18n first
@@ -305,6 +368,17 @@
 
     // Check for dashboard route first (no socket needed)
     if (checkUrlForDashboard()) {
+      return;
+    }
+
+    // Register user and check approval status
+    const userStatus = await registerUser();
+    if (userStatus === 'pending') {
+      showView('pending');
+      setupPendingRetry();
+      return;
+    } else if (userStatus === 'rejected') {
+      showRejectedView();
       return;
     }
 
@@ -471,7 +545,8 @@
           username: state.username,
           emoji: state.emoji,
           listeningMode,
-          lobbyId: state.pendingLobbyId
+          lobbyId: state.pendingLobbyId,
+          userId: state.userId
         });
         state.pendingLobbyId = null;
       });
@@ -883,6 +958,116 @@
     if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
     return (bytes / 1024 / 1024).toFixed(1) + ' MB';
   }
+
+  // Dashboard User Management
+  let dashboardUsers = [];
+
+  function fetchDashboardUsers() {
+    fetch('/api/dashboard/users', { credentials: 'include' })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then(data => {
+        dashboardUsers = data.users || [];
+        updateUserStats();
+        renderDashboardUserList();
+      })
+      .catch(err => {
+        console.error('Failed to fetch users:', err);
+      });
+  }
+
+  function updateUserStats() {
+    const counts = { approved: 0, pending: 0, rejected: 0 };
+    for (const u of dashboardUsers) {
+      if (counts[u.status] !== undefined) counts[u.status]++;
+    }
+    if (elements.usersApproved) elements.usersApproved.textContent = counts.approved;
+    if (elements.usersPending) elements.usersPending.textContent = counts.pending;
+    if (elements.usersRejected) elements.usersRejected.textContent = counts.rejected;
+  }
+
+  function renderDashboardUserList() {
+    if (!elements.dashboardUserList) return;
+
+    const searchTerm = (elements.usersSearch ? elements.usersSearch.value : '').toLowerCase();
+    const filterStatus = elements.usersFilter ? elements.usersFilter.value : 'all';
+
+    let filtered = dashboardUsers;
+    if (filterStatus !== 'all') {
+      filtered = filtered.filter(u => u.status === filterStatus);
+    }
+    if (searchTerm) {
+      filtered = filtered.filter(u =>
+        (u.username || '').toLowerCase().includes(searchTerm) ||
+        (u.email || '').toLowerCase().includes(searchTerm) ||
+        (u.user_id || '').toLowerCase().includes(searchTerm)
+      );
+    }
+
+    if (filtered.length === 0) {
+      elements.dashboardUserList.innerHTML = '<li class="dashboard-empty">No users found</li>';
+      return;
+    }
+
+    elements.dashboardUserList.innerHTML = filtered.map(user => {
+      const date = new Date(parseInt(user.created_at)).toLocaleDateString();
+      const statusClass = 'status-' + user.status;
+      const showApprove = user.status !== 'approved';
+      const showReject = user.status !== 'rejected';
+      return `
+        <li class="dashboard-user-item" data-user-id="${escapeHtml(user.id)}">
+          <div class="dashboard-user-avatar">${user.emoji || '\uD83C\uDFB5'}</div>
+          <div class="dashboard-user-info">
+            <div class="dashboard-user-name">${escapeHtml(user.username)}</div>
+            <div class="dashboard-user-meta">${escapeHtml(user.user_id)} &middot; ${user.provider || 'local'} &middot; ${date}</div>
+          </div>
+          <span class="dashboard-user-status ${statusClass}">${user.status}</span>
+          <div class="dashboard-user-actions">
+            ${showApprove ? `<button class="btn btn-small btn-approve" onclick="window.dashboardApproveUser('${escapeHtml(user.id)}')">Approve</button>` : ''}
+            ${showReject ? `<button class="btn btn-small btn-reject" onclick="window.dashboardRejectUser('${escapeHtml(user.id)}')">Reject</button>` : ''}
+          </div>
+        </li>
+      `;
+    }).join('');
+  }
+
+  window.dashboardApproveUser = function(userId) {
+    fetch(`/api/dashboard/users/${encodeURIComponent(userId)}/approve`, {
+      method: 'PUT',
+      credentials: 'include'
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then(() => {
+        fetchDashboardUsers();
+      })
+      .catch(err => {
+        console.error('Failed to approve user:', err);
+        showToast('Failed to approve user', 'error');
+      });
+  };
+
+  window.dashboardRejectUser = function(userId) {
+    fetch(`/api/dashboard/users/${encodeURIComponent(userId)}/reject`, {
+      method: 'PUT',
+      credentials: 'include'
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then(() => {
+        fetchDashboardUsers();
+      })
+      .catch(err => {
+        console.error('Failed to reject user:', err);
+        showToast('Failed to reject user', 'error');
+      });
+  };
 
   function fetchCachedSongs() {
     fetch('/api/dashboard/cache/songs', { credentials: 'include' })
@@ -1340,6 +1525,9 @@
     if (elements.dashboardView) {
       elements.dashboardView.classList.remove('active');
     }
+    if (elements.pendingView) {
+      elements.pendingView.classList.remove('active');
+    }
 
     // Stop dashboard polling when leaving
     if (dashboardInterval) {
@@ -1387,6 +1575,12 @@
         fetchDashboardStats();
         fetchCacheStats();
       }, 2000);
+      // User management
+      fetchDashboardUsers();
+      if (elements.usersSearch) elements.usersSearch.addEventListener('input', renderDashboardUserList);
+      if (elements.usersFilter) elements.usersFilter.addEventListener('change', renderDashboardUserList);
+    } else if (viewName === 'pending' && elements.pendingView) {
+      elements.pendingView.classList.add('active');
     }
   }
 
@@ -1397,11 +1591,11 @@
     const selectedMode = document.querySelector('input[name="listeningMode"]:checked');
     const listeningMode = selectedMode ? selectedMode.value : 'synchronized';
     const name = elements.lobbyNameInput ? elements.lobbyNameInput.value.trim() : '';
-    socket.emit('lobby:create', { username: state.username, emoji: state.emoji, listeningMode, name: name || undefined });
+    socket.emit('lobby:create', { username: state.username, emoji: state.emoji, listeningMode, name: name || undefined, userId: state.userId });
   }
 
   function joinLobby(lobbyId) {
-    socket.emit('lobby:join', { lobbyId, username: state.username, emoji: state.emoji });
+    socket.emit('lobby:join', { lobbyId, username: state.username, emoji: state.emoji, userId: state.userId });
   }
 
   function leaveLobby() {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -338,6 +338,22 @@
     </section>
   </div>
 
+  <!-- Pending Approval View -->
+  <div id="pending-view" class="view">
+    <main class="landing-content">
+      <div class="logo">
+        <img class="logo-icon" src="/icon-192.png" alt="listen-along">
+        <h1>listen-along</h1>
+      </div>
+      <div class="pending-approval-card">
+        <div id="pending-icon" class="pending-icon">&#x23F3;</div>
+        <h2 id="pending-title">Waiting for Approval</h2>
+        <p id="pending-message" class="pending-message">Your account is pending admin approval. You'll be able to access lobbies once approved.</p>
+        <button id="pending-retry-btn" class="btn btn-primary">Check Status</button>
+      </div>
+    </main>
+  </div>
+
   <!-- Dashboard View -->
   <div id="dashboard-view" class="view">
     <header class="dashboard-header">
@@ -369,6 +385,29 @@
           <li class="dashboard-empty" data-i18n="dashboard.noActiveLobbies">No active lobbies</li>
         </ul>
       </section>
+      <section class="dashboard-users">
+        <div class="users-header">
+          <h2>User Management</h2>
+        </div>
+        <div class="users-stats-inline">
+          <span class="cache-stat-pill user-approved"><span id="users-approved">0</span> approved</span>
+          <span class="cache-stat-pill user-pending"><span id="users-pending">0</span> pending</span>
+          <span class="cache-stat-pill user-rejected"><span id="users-rejected">0</span> rejected</span>
+        </div>
+        <div class="users-controls">
+          <input type="text" id="users-search" class="cache-search-input" placeholder="Search users...">
+          <select id="users-filter" class="cache-sort-select">
+            <option value="all">All users</option>
+            <option value="pending">Pending</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+          </select>
+        </div>
+        <ul id="dashboard-user-list" class="dashboard-user-list">
+          <li class="dashboard-empty">No registered users</li>
+        </ul>
+      </section>
+
       <section class="dashboard-cache">
         <div class="cache-header">
           <h2 data-i18n="dashboard.songCache">Song Cache</h2>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -3065,3 +3065,164 @@ html, body {
   padding: 2rem 0;
   font-size: 0.875rem;
 }
+
+/* Pending Approval View */
+.pending-approval-card {
+  background: var(--bg-elevated);
+  border-radius: var(--border-radius-lg);
+  padding: 2.5rem 2rem;
+  text-align: center;
+  max-width: 400px;
+  width: 100%;
+}
+
+.pending-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.pending-approval-card h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.pending-message {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin-bottom: 1.5rem;
+}
+
+/* Dashboard User Management */
+.dashboard-users {
+  margin-top: 2rem;
+}
+
+.users-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.users-header h2 {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.users-stats-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin-bottom: 0.75rem;
+}
+
+.cache-stat-pill.user-approved { background: rgba(29, 185, 84, 0.15); color: var(--primary); }
+.cache-stat-pill.user-pending { background: rgba(255, 193, 7, 0.15); color: #ffc107; }
+.cache-stat-pill.user-rejected { background: rgba(220, 53, 69, 0.15); color: #dc3545; }
+
+.users-controls {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.users-controls input {
+  flex: 1;
+}
+
+.dashboard-user-list {
+  list-style: none;
+}
+
+.dashboard-user-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-elevated);
+  border-radius: var(--border-radius);
+  margin-bottom: 0.5rem;
+}
+
+.dashboard-user-avatar {
+  font-size: 1.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-surface);
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.dashboard-user-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.dashboard-user-name {
+  font-weight: 600;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard-user-meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.dashboard-user-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.status-pending {
+  background: rgba(255, 193, 7, 0.15);
+  color: #ffc107;
+}
+
+.status-approved {
+  background: rgba(29, 185, 84, 0.15);
+  color: var(--primary);
+}
+
+.status-rejected {
+  background: rgba(220, 53, 69, 0.15);
+  color: #dc3545;
+}
+
+.dashboard-user-actions {
+  display: flex;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.btn-approve {
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn-approve:hover {
+  background: var(--primary-hover);
+}
+
+.btn-reject {
+  background: #dc3545;
+  color: #fff;
+}
+
+.btn-reject:hover {
+  background: #c82333;
+}


### PR DESCRIPTION
## Summary
- New users land in "pending" state after OAuth login, see a "Waiting for Approval" page
- Dashboard shows all registered users with status badges (pending=yellow, approved=green, rejected=red)
- Admin can approve/reject users from dashboard with one click
- Only approved users can access lobbies and the app
- Search/filter users by name or email
- New API endpoints: GET /api/auth/status, PUT /api/dashboard/users/:id/approve

Closes #97